### PR TITLE
fix: allow to use browser cryptography when in wasm

### DIFF
--- a/cryptography/lib/browser.dart
+++ b/cryptography/lib/browser.dart
@@ -20,4 +20,4 @@
 library;
 
 export 'src/browser/browser_cryptography_when_not_browser.dart'
-    if (dart.library.html) 'src/browser/browser_cryptography.dart';
+    if (dart.library.js_interop) 'src/browser/browser_cryptography.dart';

--- a/cryptography/lib/cryptography_plus.dart
+++ b/cryptography/lib/cryptography_plus.dart
@@ -29,7 +29,7 @@ library;
 import 'package:cryptography_plus/cryptography_plus.dart';
 
 export 'src/browser/browser_cryptography_when_not_browser.dart'
-    if (dart.library.html) 'src/browser/browser_cryptography.dart';
+    if (dart.library.js_interop) 'src/browser/browser_cryptography.dart';
 export 'src/cryptography/algorithms.dart';
 export 'src/cryptography/cipher.dart';
 export 'src/cryptography/cipher_state.dart';

--- a/cryptography/lib/src/dart/blake2b.dart
+++ b/cryptography/lib/src/dart/blake2b.dart
@@ -16,7 +16,7 @@ import 'package:cryptography_plus/cryptography_plus.dart';
 import 'package:cryptography_plus/dart.dart';
 
 import 'blake2b_impl_vm.dart'
-    if (dart.library.html) 'blake2b_impl_browser.dart';
+    if (dart.library.js_interop) 'blake2b_impl_browser.dart';
 
 /// [Blake2b] implemented in pure Dart.
 ///

--- a/cryptography/lib/src/helpers/random_bytes.dart
+++ b/cryptography/lib/src/helpers/random_bytes.dart
@@ -20,7 +20,7 @@ import 'package:cryptography_plus/helpers.dart';
 import '../../cryptography_plus.dart';
 
 export 'random_bytes_impl_default.dart'
-    if (dart.library.html) 'random_bytes_impl_browser.dart';
+    if (dart.library.js_interop) 'random_bytes_impl_browser.dart';
 
 const _hexChars = [
   '0',

--- a/cryptography_flutter/lib/src/_internal.dart
+++ b/cryptography_flutter/lib/src/_internal.dart
@@ -19,10 +19,10 @@ import 'package:flutter/services.dart';
 
 import '../cryptography_flutter_plus.dart';
 import '_internal_impl_non_browser.dart'
-    if (dart.library.html) '_internal_impl_browser.dart';
+    if (dart.library.js_interop) '_internal_impl_browser.dart';
 
 export '_internal_impl_non_browser.dart'
-    if (dart.library.html) '_internal_impl_browser.dart';
+    if (dart.library.js_interop) '_internal_impl_browser.dart';
 
 const MethodChannel _methodChannel = MethodChannel('cryptography_flutter');
 


### PR DESCRIPTION
I was recently testing this package with wasm. I noticed that when the application is compiled to wasm, the package does not use the browser crypto API and instead fallbacks to the dart implementation, which even in wasm is way slower than the browser provided crypto API.

The PR makes fixes to enable the browser crypto API be used in JS / wasm targets.
