### PR TITLE
fix: avoid comparing destroyed bytes

### DIFF
--- a/cryptography/lib/src/cryptography/secret_key.dart
+++ b/cryptography/lib/src/cryptography/secret_key.dart
@@ -179,6 +179,7 @@ class SecretKeyData extends SecretKey {
       return false;
     }
     return other is SecretKeyData &&
+        !other.hasBeenDestroyed &&
         constantTimeBytesEquality.equals(bytes, other.bytes);
   }
 


### PR DESCRIPTION
Make `operator ==` symmetric by also checking that the argument bytes are not destroyed before reading them.

In the `operator ==` implementation for `SecretKeyData` the receiver is first checked for destroyed bytes which are considered unequal to any other key. The argument was not checked for destroyed bytes, so in an expression `notDestroyed == destroyed` the `bytes` getter on the argument would throw a `StateError`.

This exception is masked in tests by the `equals` matcher which currently treats an exception from `operator ==` the same as if it had returned `false`. In an upcoming release this exception will stop being masked and will start to cause test failures.