### PR TITLE
Fix exception in SecretKey equality operator

### DIFF
--- a/cryptography/CHANGELOG.md
+++ b/cryptography/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+- Avoid exception when checking whether a destroyed secret key is compared for
+  equality against a non-destroyed key.
+
 ## 2.7.1
 
 **Release of package under new name**

--- a/cryptography/lib/src/cryptography/secret_key.dart
+++ b/cryptography/lib/src/cryptography/secret_key.dart
@@ -179,6 +179,7 @@ class SecretKeyData extends SecretKey {
       return false;
     }
     return other is SecretKeyData &&
+        !other.hasBeenDestroyed &&
         constantTimeBytesEquality.equals(bytes, other.bytes);
   }
 


### PR DESCRIPTION
Currently if a key is destroyed and then passed to `operator ==` it will cause an exception. This exception does happen in practice in the tests, but it is masked by the current behavior of `equals` in `package:matcher` which treats an exception identically to returning `false`. When that behavior changes the current test would fail without this fix.