### PR TITLE
Added documentation to close #23

### DIFF
--- a/pkgs/cryptography_flutter_plus/lib/src/background/background_cipher.dart
+++ b/pkgs/cryptography_flutter_plus/lib/src/background/background_cipher.dart
@@ -238,6 +238,13 @@ mixin BackgroundCipherMixin implements BackgroundCipher {
     return clearText;
   }
 
+  /// Encrypts a cleartext.
+  ///
+  /// The [clearText] will be converted to a [Uint8List] before encryption. If
+  /// the [clearText] contains any non-8-bit values, they will be truncated to 8
+  /// bits. See [Uint8List] for details.
+  ///
+  /// For other arguments, see [StreamingCipher.encrypt] and [Cipher.encrypt].
   @override
   Future<SecretBox> encrypt(
     List<int> clearText, {

--- a/pkgs/cryptography_flutter_plus/lib/src/flutter/flutter_cipher.dart
+++ b/pkgs/cryptography_flutter_plus/lib/src/flutter/flutter_cipher.dart
@@ -298,6 +298,13 @@ mixin FlutterCipherMixin
     );
   }
 
+  /// Encrypts a cleartext.
+  ///
+  /// The [clearText] will be converted to a [Uint8List] before encryption. If
+  /// the [clearText] contains any non-8-bit values, they will be truncated to 8
+  /// bits. See [Uint8List] for details.
+  ///
+  /// For other arguments, see [StreamingCipher.encrypt] and [Cipher.encrypt].
   @override
   Future<SecretBox> encrypt(
     List<int> clearText, {


### PR DESCRIPTION
This pull request addresses the documentation issue raised in #23.

Changing the function signature to `Uint8List clearText` was not possible due to the type `List<int>` being required for different (e.g. browser) implementations.